### PR TITLE
Updated to yivi-frontend instead of deprecated irma-frontend

### DIFF
--- a/18plus/index.en.html
+++ b/18plus/index.en.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script src="messages.en.js" defer></script>
         <script src="18plusdemo.js" defer></script>
     </head>

--- a/18plus/index.nl.html
+++ b/18plus/index.nl.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
     <script src="../assets/jquery.min.js" defer></script>
-    <script src="../assets/irma.js" defer></script>
+    <script src="../assets/yivi.js" defer></script>
     <script src="messages.nl.js" defer></script>
     <script src="18plusdemo.js" defer></script>
 </head>

--- a/address/index.en.html
+++ b/address/index.en.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script src="messages.en.js" defer></script>
         <script src="adresdemo.js" defer></script>
 

--- a/address/index.nl.html
+++ b/address/index.nl.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script src="messages.nl.js" defer></script>
         <script src="adresdemo.js" defer></script>
 

--- a/beingalive/index.en.html
+++ b/beingalive/index.en.html
@@ -6,7 +6,7 @@
     <title>IRMA Attestatio de Vita demo</title>
     <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
     <script src="../assets/jquery.min.js" defer></script>
-    <script src="../assets/irma.js" defer></script>
+    <script src="../assets/yivi.js" defer></script>
     <script src="messages.en.js" defer></script>
     <script src="beingalivedemo.js" defer></script>
 </head>

--- a/beingalive/index.nl.html
+++ b/beingalive/index.nl.html
@@ -6,7 +6,7 @@
     <title>IRMA Attestatie de Vita demo</title>
     <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
     <script src="../assets/jquery.min.js" defer></script>
-    <script src="../assets/irma.js" defer></script>
+    <script src="../assets/yivi.js" defer></script>
     <script src="messages.nl.js" defer></script>
     <script src="beingalivedemo.js" defer></script>
 </head>

--- a/build_artifacts.sh
+++ b/build_artifacts.sh
@@ -9,7 +9,7 @@ mkdir -p "$DIR/assets"
 cp "$DIR/node_modules/jquery/dist/jquery.min.js" "$DIR/assets/jquery.min.js"
 cp "$DIR/node_modules/bootstrap/dist/css/bootstrap.min.css" "$DIR/assets/bootstrap.min.css"
 cp "$DIR/node_modules/bootstrap/dist/js/bootstrap.min.js" "$DIR/assets/bootstrap.min.js"
-cp "$DIR/node_modules/@privacybydesign/irma-frontend/dist/irma.js" "$DIR/assets/irma.js"
+cp "$DIR/node_modules/@privacybydesign/yivi-frontend/dist/yivi.js" "$DIR/assets/yivi.js"
 
 rm -rf "$DIR/build"
 

--- a/irmaTubePremium/index.en.html
+++ b/irmaTubePremium/index.en.html
@@ -8,7 +8,7 @@
         <link href="../assets/bootstrap.min.css" rel="stylesheet"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
 
         <script src="messages.en.js" defer></script>
         <script src="premiumdemo.js" defer></script>

--- a/irmaTubePremium/index.nl.html
+++ b/irmaTubePremium/index.nl.html
@@ -8,7 +8,7 @@
         <link href="../assets/bootstrap.min.css" rel="stylesheet" />
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
 
         <script src="messages.nl.js" defer></script>
         <script src="premiumdemo.js" defer></script>

--- a/mail/index.en.html
+++ b/mail/index.en.html
@@ -8,7 +8,7 @@
         <link href="../assets/bootstrap.min.css" rel="stylesheet"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
 
         <script src="messages.en.js" defer></script>
         <script src="maildemo.js" defer></script>

--- a/mail/index.nl.html
+++ b/mail/index.nl.html
@@ -8,7 +8,7 @@
         <link href="../assets/bootstrap.min.css" rel="stylesheet"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
 
         <script src="messages.nl.js" defer></script>
         <script src="maildemo.js" defer></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,51 @@
+{
+  "name": "irma-demo-pages",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "irma-demo-pages",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@privacybydesign/yivi-frontend": "^0.1.3",
+        "bootstrap": "^4.3.1",
+        "jquery": "^3.5.0",
+        "popper.js": "^1.14.7"
+      }
+    },
+    "node_modules/@privacybydesign/yivi-frontend": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@privacybydesign/yivi-frontend/-/yivi-frontend-0.1.3.tgz",
+      "integrity": "sha512-cT6JRbli8HaTVB2z0Tmvrd0ln2ByHbcpTNHnOCbvl0SeLXfBGGIOUMpV+HwIg5xMuznMaonjA0572v7tL8Wc9w==",
+      "license": "SEE LICENSE IN REPOSITORY"
+    },
+    "node_modules/bootstrap": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.14.7"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
+      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==",
+      "license": "MIT"
+    },
+    "node_modules/popper.js": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "main": "index.js",
   "repository": "https://gitlab.science.ru.nl/irma/irma-demo-pages",
   "contributors": [
-    "Ivar Derksen",
+    "Caesar Groep",
     "Privacy by Design Foundation"
   ],
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@privacybydesign/irma-frontend": "^0.4.1",
+    "@privacybydesign/yivi-frontend": "^0.1.3",
     "bootstrap": "^4.3.1",
     "jquery": "^3.5.0",
     "popper.js": "^1.14.7"

--- a/signature/index.en.html
+++ b/signature/index.en.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="sign.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script type="text/javascript" src="messages.en.js" defer></script>
         <script type="text/javascript" src="sign.js" defer></script>
         <script src="../assets/bootstrap.min.js" defer></script>

--- a/signature/index.nl.html
+++ b/signature/index.nl.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="sign.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script type="text/javascript" src="messages.nl.js" defer></script>
         <script type="text/javascript" src="sign.js" defer></script>
         <script src="../assets/bootstrap.min.js" defer></script>

--- a/start_session.js
+++ b/start_session.js
@@ -1,6 +1,6 @@
 function start_session(type, lang, success_fun, cancelled_fun, error_fun) {
     console.log("Button clicked");
-    irma.newPopup({
+    yivi.newPopup({
         language: lang,
         session: {
             url: '..',

--- a/student/index.en.html
+++ b/student/index.en.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script src="messages.en.js" defer></script>
         <script src="studentdemo.js" defer></script>
     </head>

--- a/student/index.nl.html
+++ b/student/index.nl.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="../assets/bootstrap.min.css"/>
 
         <script src="../assets/jquery.min.js" defer></script>
-        <script src="../assets/irma.js" defer></script>
+        <script src="../assets/yivi.js" defer></script>
         <script src="messages.nl.js" defer></script>
         <script src="studentdemo.js" defer></script>
     </head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@privacybydesign/irma-frontend@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-frontend/-/irma-frontend-0.4.1.tgz#b1afafa2efe00da464edb444c9ffbb460c05cbdf"
-  integrity sha512-C0wJw6mr6L5ym7s3B+y+wfb1dqtym9rqHJq2ypQdOOdDRfCqKblyXnmzp1/LP8eIIpHKjJ4rE678CGHZFM3B1w==
+"@privacybydesign/yivi-frontend@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@privacybydesign/yivi-frontend/-/yivi-frontend-0.1.3.tgz"
+  integrity sha512-cT6JRbli8HaTVB2z0Tmvrd0ln2ByHbcpTNHnOCbvl0SeLXfBGGIOUMpV+HwIg5xMuznMaonjA0572v7tL8Wc9w==
 
 bootstrap@^4.3.1:
   version "4.3.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.3.1.tgz#280ca8f610504d99d7b6b4bfc4b68cec601704ac"
+  resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz"
   integrity sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag==
 
-jquery@^3.5.0:
+jquery@^3.5.0, "jquery@1.9.1 - 3":
   version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz"
   integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 popper.js@^1.14.7:
   version "1.15.0"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
+  resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz"
   integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==


### PR DESCRIPTION
Upgraded frontend dependency so that we use `@privacybydesign/yivi-frontend` instead of deprecated `@privacybydesign/irma-frontend`. Now we have a nice QR aswell. 

https://www.npmjs.com/package/@privacybydesign/yivi-frontend 

![image](https://github.com/user-attachments/assets/d8ce706f-03d8-40f7-887c-5faab25106d1)
