### PR TITLE
fix: SURFconext links and missing id

### DIFF
--- a/demos/student/index.en.html
+++ b/demos/student/index.en.html
@@ -49,7 +49,7 @@ have the Yivi
 app <a href="https://yivi.app/#download">installed</a>
 with at least the card with educational data loaded into the app.
 This can be done
-via <a href="https://privacybydesign.foundation/issuance/surfnet?action=login">SURFconext
+via <a href="https://privacybydesign.foundation/issuance/surfconext/surfconext/?action=login">SURFconext
 issuance webpage</a> of the Privacy by Design foundation. A succesful
 check that the visitor is a student gives access to special offers.
 </p>

--- a/demos/student/index.nl.html
+++ b/demos/student/index.nl.html
@@ -15,11 +15,11 @@
     </head>
     <body>
 
-<div class="container mt-5" id="main">
     <header>
         <h1>Toegang voor studenten met Yivi</h1>
         </header>
 
+<div class="container mt-5" id="main">
 
 <div id="result_status"></div>
 

--- a/demos/student/index.nl.html
+++ b/demos/student/index.nl.html
@@ -15,7 +15,7 @@
     </head>
     <body>
 
-<div class="container mt-5">
+<div class="container mt-5" id="main">
     <header>
         <h1>Toegang voor studenten met Yivi</h1>
         </header>

--- a/demos/student/index.nl.html
+++ b/demos/student/index.nl.html
@@ -50,7 +50,7 @@ Yivi
 app <a href="https://yivi.app/#download">ge&iuml;nstalleerd</a>
 hebben en daarin tenminste het onderwijs kaartje geladen hebben. Dat
 kan via
-de <a href="https://privacybydesign.foundation/uitgifte/surfnet?action=login">SURFconext
+de <a href="https://privacybydesign.foundation/uitgifte/surfconext/surfconext/?action=login">SURFconext
 uitgifte webpagina</a> van de stichting Privacy by Design. Succesvolle
 controle dat de bezoeker student is geeft vervolgens toegang tot
 aanbiedingen.
@@ -85,7 +85,7 @@ vermijden.
 
 <li> Studeer of werk je aan een hogere onderwijs instelling, maar komt
 deze instelling niet voor in de lijst op
-de <a href="https://privacybydesign.foundation/issuance/surfconext/surfconext/">SURFconext
+de <a href="https://privacybydesign.foundation/uitgifte/surfconext/surfconext/">SURFconext
 uitgifte pagina</a>, dan heeft je instelling de aansluiting met de
 stichting <a href="https://privacybydesign.foundation/">Privacy by
 Design</a> niet "aangezet". In dat geval kun je de hier benodigde


### PR DESCRIPTION
Issues fixed on the Dutch and English pages:
* Fixed the broken SURFconext links on the Dutch and English page.
* Replaced the English link on the Dutch page with the Dutch link.

Issues fixed on the Dutch page:
* Fixed the NL page by adding a missing "main" id, because the student check result won't show without it.
* Also moved the header so it's visible after student check (just like the English page currently does).