### PR TITLE
ci: bump workflow actions to latest (fix stale grype DB)

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check whether this event is the HEAD of main
         continue-on-error: true
@@ -33,7 +33,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -42,17 +42,17 @@ jobs:
             type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build container and export to local Docker
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true
@@ -71,13 +71,13 @@ jobs:
           output-format: sarif
 
       - name: Upload Anchore scan SARIF report
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: ${{ !cancelled() }}
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
       - name: Push image to GitHub Container Registry
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
         with:
           push: true

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -61,7 +61,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan Image
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v7
         id: scan
         with:
           image: local/atumd:scan


### PR DESCRIPTION
## Summary
- The `Scan Image` step in `.github/workflows/delivery.yml` was failing on `master` ([run #26225189971](https://github.com/privacybydesign/irma-demos/actions/runs/26225189971/job/77170224954)) with:
  > db could not be loaded: the vulnerability database was built 10 weeks ago (max allowed age is 5 days)

  `anchore/scan-action@v3` pins grype `v0.74.4`, whose bundled vulnerability DB has aged past grype's 5-day max. Bumping to `@v7` pulls in a current grype with a fresh DB. Inputs we use (`image`, `only-fixed`, `fail-build`, `severity-cutoff`, `output-format`) and the `sarif` output are unchanged in v7.
- While here, bumped the rest of the workflow's actions to current major versions:
  - `actions/checkout` v4 → v6
  - `docker/metadata-action` v5 → v6
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/build-push-action` v5 → v7
  - `github/codeql-action/upload-sarif` v3 → v4 (also clears the v3 deprecation warning that appeared in the failing run)

## Test plan
- [ ] CI passes on this PR (Scan Image step succeeds, SARIF uploads, image builds).