### PR TITLE
chore: update angrygames URL to angrygames.yivi.app

### DIFF
--- a/demos/18plus/index.en.html
+++ b/demos/18plus/index.en.html
@@ -60,10 +60,12 @@ the Yivi documentation <a href="https://docs.yivi.app/">webpage</a> with more in
 <li> Buttons like the above one are especially relevant for webshops
 that have a legal obligation to perform age verification when offering
 violent or possibly offensive games or films, or by gambling
-sites. The button could also be used to regulate online access to
-catch up TV programs. Currently, many of these sites do not have
-proper age checks because there is no user-friendly (and cheap)
-technology available. With Yivi this excuse can no longer be used.
+sites. This is illustrated in a dedicated
+<a href="https://angrygames.yivi.app">angry games</a> demo. The button
+could also be used to regulate online access to catch up TV
+programs. Currently, many of these sites do not have proper age checks
+because there is no user-friendly (and cheap) technology
+available. With Yivi this excuse can no longer be used.
 
 <li> With Yivi it is possible to perform not only "older than" but
 also "younger than" checks, such as "younger than 16" or "younger than

--- a/demos/18plus/index.nl.html
+++ b/demos/18plus/index.nl.html
@@ -65,7 +65,7 @@ de yivi documentatie <a href="https://docs.yivi.app/">webpagina</a> met meer inf
 <a href="http://maxius.nl/wetboek-van-strafrecht/artikel240a">wettelijke
 eisen</a> moeten voldoen bij het aanbieden van bijvoorbeeld
 gewelddadige en/of aanstootgevende games of films. Dit is uitgewerkt
-in een speciale <a href="https://angrygames.nl">angry games</a>
+in een speciale <a href="https://angrygames.yivi.app">angry games</a>
 demo. Ook zou met zo'n knop de toegang gereguleerd kunnen worden tot
 bepaalde TV programma's op uitzending-gemist sites. Tot nu toe wordt
 door de overheid veelal door de vingers gezien dat webwinkels geen

--- a/index.html
+++ b/index.html
@@ -23,40 +23,40 @@
             <dl class="row">
                 <dt class="col-sm-4">Log in with e-mail address</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/mail/index.en.html'">E-mail log in</button>
+                    <a class="custom-button" href="/demos/mail/index.en.html">E-mail log in</a>
                 </dd>
                 <dt class="col-sm-4">Yivi signatures for permissions and statements</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/signature/index.en.html'">Yivi signatures</button>
+                    <a class="custom-button" href="/demos/signature/index.en.html">Yivi signatures</a>
                 </dd>
                 <dt class="col-sm-4">Submitting address information by automatic form-filling</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/address/index.en.html'">Filling in address</button>
+                    <a class="custom-button" href="/demos/address/index.en.html">Filling in address</a>
                 </dd>
                 <dt class="col-sm-4">Verification whether someone is a student</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/student/index.en.html'">Student check</button>
+                    <a class="custom-button" href="/demos/student/index.en.html">Student check</a>
                 </dd>
                 <dt class="col-sm-4">Age verification</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/18plus/index.en.html'">18+ check</button>
-                    <button class="custom-button" onclick="window.location.href='https://angrygames.yivi.app/'">Angry Games demo</button>
+                    <a class="custom-button" href="/demos/18plus/index.en.html">18+ check</a>
+                    <a class="custom-button" href="https://angrygames.yivi.app">Angry Games demo</a>
                 </dd>
                 <dt class="col-sm-4">Registration and verification for watching movies online</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='https://yivitube.yivi.app'">YiviTube</button>
+                    <a class="custom-button" href="https://yivitube.yivi.app">YiviTube</a>
                 </dd>
                 <dt class="col-sm-4">Chained Yivi sessions</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/irmaTubePremium/index.en.html'">YiviTube Premium</button>
+                    <a class="custom-button" href="/demos/irmaTubePremium/index.en.html">YiviTube Premium</a>
                 </dd>
                 <dt class="col-sm-4">Verification whether someone is being alive</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/beingalive/index.en.html'">Attestatio de vita demo</button>
+                    <a class="custom-button" href="/demos/beingalive/index.en.html">Attestatio de vita demo</a>
                 </dd>
                 <dt class="col-sm-4">IBAN Verification</dt>
                 <dd class="col-sm-8 mb-3">
-                    <button class="custom-button" onclick="window.location.href='/demos/iban/index.en.html'">IBAN verification</button>
+                    <a class="custom-button" href="/demos/iban/index.en.html">IBAN verification</a>
                 </dd>
             </dl>
         </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                 <dt class="col-sm-4">Age verification</dt>
                 <dd class="col-sm-8 mb-3">
                     <button class="custom-button" onclick="window.location.href='/demos/18plus/index.en.html'">18+ check</button>
-                    <button class="custom-button" onclick="window.location.href='https://angrygames.nl/'">Angry Games demo</button>
+                    <button class="custom-button" onclick="window.location.href='https://angrygames.yivi.app/'">Angry Games demo</button>
                 </dd>
                 <dt class="col-sm-4">Registration and verification for watching movies online</dt>
                 <dd class="col-sm-8 mb-3">


### PR DESCRIPTION
## Summary
- Replace `angrygames.nl` with `angrygames.yivi.app` in `index.html` and `demos/18plus/index.nl.html`. The `.nl` domain no longer resolves; the demo is now hosted at the canonical `*.yivi.app` subdomain alongside the other Yivi demos (e.g. `yivitube.yivi.app`).
- Convert the demo-list buttons in `index.html` from `<button onclick="window.location.href=...">` to `<a class="custom-button" href="...">` for keyboard navigation, right-click "open in new tab", and correct screen-reader semantics. The existing `.custom-button` CSS already has `display: inline-block` and `text-decoration: none`, so visual styling is unchanged.
- Normalize the angrygames URL to no trailing slash to match the convention used by `yivitube.yivi.app` and the link in `demos/18plus/index.nl.html`.
- Add the angry games cross-reference to `demos/18plus/index.en.html` so the English page is no longer asymmetric with its Dutch counterpart.

## Test plan
- [x] Served the repo locally and opened `index.html`: the "Angry Games demo" anchor renders identically to the other custom buttons and points to `https://angrygames.yivi.app` (verified via DOM inspection).
- [x] Confirmed every demo entry in `index.html` is now an `<a>` element (10 anchors, 0 remaining `<button onclick>` navigation handlers).
- [x] Opened `demos/18plus/index.nl.html`: the inline "angry games" link points to `https://angrygames.yivi.app`.
- [x] Opened `demos/18plus/index.en.html`: the new "angry games" link is present in the webshops bullet and points to `https://angrygames.yivi.app`.