### PR TITLE
ci: rename local scan tag from atumd to irma-demos

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           load: true
-          tags: local/atumd:scan
+          tags: local/irma-demos:scan
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -64,7 +64,7 @@ jobs:
         uses: anchore/scan-action@v7
         id: scan
         with:
-          image: local/atumd:scan
+          image: local/irma-demos:scan
           only-fixed: true
           fail-build: true
           severity-cutoff: critical


### PR DESCRIPTION
## Summary

Renames the local scan image tag in `.github/workflows/delivery.yml` from `local/atumd:scan` to `local/irma-demos:scan` in both the build step and the anchore scan step.

The `atumd` name was a copy-paste leftover from the [`privacybydesign/atumd`](https://github.com/privacybydesign/atumd) workflow this file was adapted from. The tag is only used locally to hand the built image from the build step to the scan step within the same job, so the old name was functionally harmless — but misleading in CI logs.

Closes #50